### PR TITLE
Improve map memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,8 @@ panic = "abort"
 codegen-units = 1
 overflow-checks = true
 
+
+
 [workspace.dependencies]
 # rostl-rodb = { path = "crates/rodb" }
 rostl-datastructures = { path = "crates/datastructures", version = "0.1.0-alpha2" }

--- a/crates/datastructures/src/array.rs
+++ b/crates/datastructures/src/array.rs
@@ -13,7 +13,6 @@ use rostl_oram::{
   recursive_oram::RecursivePositionMap,
 };
 use rostl_primitives::{indexable::Length, traits::Cmov};
-use static_assertions::const_assert;
 
 /// A fixed sized array defined at compile time.
 /// The size of the array is public.
@@ -349,7 +348,11 @@ where
   /// Creates a new `MultiWayArray` with the given size `n`.
   pub fn new(n: usize) -> Self {
     assert!(W.is_power_of_two(), "W must be a power of two due to all the ilog2's here");
-    Self { data: CircuitORAM::new(n), pos_map: from_fn(|_| RecursivePositionMap::new(n)), rng: rand::rng() }
+    Self {
+      data: CircuitORAM::new(n),
+      pos_map: from_fn(|_| RecursivePositionMap::new(n)),
+      rng: rand::rng(),
+    }
   }
 
   fn get_real_index(&self, subarray: usize, index: usize) -> usize {
@@ -402,6 +405,7 @@ impl<T: Cmov + Pod, const W: usize> Length for MultiWayArray<T, W> {
 // UNDONE(git-31): Implement read and write that have an enable flag (maybe_read, maybe_write).
 
 #[cfg(test)]
+#[allow(clippy::reversed_empty_ranges)]
 mod tests {
   use super::*;
 
@@ -431,12 +435,12 @@ mod tests {
     }};
   }
 
-   macro_rules! m_test_multiway_array_exhaustive {
+  macro_rules! m_test_multiway_array_exhaustive {
     ($arraytp:ident, $valtp:ty, $size:expr, $ways:expr) => {{
       println!("Testing {} with size {}", stringify!($arraytp), $size);
       let mut arr = $arraytp::<$valtp, $ways>::new($size);
       assert_eq!(arr.len(), $size);
-      for w in 0..$ways {  
+      for w in 0..$ways {
         for i in 0..$size {
           let mut value = Default::default();
           arr.read(w, i, &mut value);
@@ -445,18 +449,18 @@ mod tests {
       }
       assert_eq!(arr.len(), $size);
 
-      for w in 0..$ways {  
+      for w in 0..$ways {
         for i in 0..($size / $ways) {
-          let value = (i+w) as $valtp;
+          let value = (i + w) as $valtp;
           arr.write(w, i, value);
         }
       }
       assert_eq!(arr.len(), $size);
-      for w in 0..$ways {  
+      for w in 0..$ways {
         for i in 0..($size / $ways) {
           let mut value = Default::default();
           arr.read(w, i, &mut value);
-          let v = (i+w) as $valtp;
+          let v = (i + w) as $valtp;
           assert_eq!(value, v);
         }
       }

--- a/crates/datastructures/src/array.rs
+++ b/crates/datastructures/src/array.rs
@@ -327,7 +327,7 @@ impl<T: Cmov + Pod> Length for DynamicArray<T> {
   }
 }
 
-/// A set of `W`` subarrays that can be used to store a fixed number of total elements defined at `new` time. It is leaked which subarray is being accessed.
+/// A set of `W` subarrays that can be used to store a fixed number of total elements defined at `new` time. It is leaked which subarray is being accessed.
 ///
 #[derive(Debug)]
 pub struct MultiWayArray<T, const W: usize>
@@ -346,7 +346,7 @@ impl<T, const W: usize> MultiWayArray<T, W>
 where
   T: Cmov + Pod + Default + std::fmt::Debug,
 {
-  /// Creates a new `LongArray` with the given size `n`.
+  /// Creates a new `MultiWayArray` with the given size `n`.
   pub fn new(n: usize) -> Self {
     assert!(W.is_power_of_two(), "W must be a power of two due to all the ilog2's here");
     Self { data: CircuitORAM::new(n), pos_map: from_fn(|_| RecursivePositionMap::new(n)), rng: rand::rng() }
@@ -405,7 +405,7 @@ impl<T: Cmov + Pod, const W: usize> Length for MultiWayArray<T, W> {
 mod tests {
   use super::*;
 
-  macro_rules! m_test_fixed_array_exaustive {
+  macro_rules! m_test_fixed_array_exhaustive {
     ($arraytp:ident, $valtp:ty, $size:expr) => {{
       println!("Testing {} with size {}", stringify!($arraytp), $size);
       let mut arr = $arraytp::<$valtp, $size>::new();
@@ -431,7 +431,7 @@ mod tests {
     }};
   }
 
-   macro_rules! m_test_multiway_array_exaustive {
+   macro_rules! m_test_multiway_array_exhaustive {
     ($arraytp:ident, $valtp:ty, $size:expr, $ways:expr) => {{
       println!("Testing {} with size {}", stringify!($arraytp), $size);
       let mut arr = $arraytp::<$valtp, $ways>::new($size);
@@ -464,7 +464,7 @@ mod tests {
     }};
   }
 
-  macro_rules! m_test_dynamic_array_exaustive {
+  macro_rules! m_test_dynamic_array_exhaustive {
     ($arraytp:ident, $valtp:ty, $size:expr) => {{
       println!("Testing {} with size {}", stringify!($arraytp), $size);
       let mut arr = $arraytp::<$valtp>::new($size);
@@ -523,60 +523,58 @@ mod tests {
 
   #[test]
   fn test_fixed_arrays() {
-    m_test_fixed_array_exaustive!(ShortArray, u32, 1);
-    m_test_fixed_array_exaustive!(ShortArray, u32, 2);
-    m_test_fixed_array_exaustive!(ShortArray, u32, 3);
-    m_test_fixed_array_exaustive!(ShortArray, u64, 15);
-    m_test_fixed_array_exaustive!(ShortArray, u8, 33);
-    m_test_fixed_array_exaustive!(ShortArray, u64, 200);
+    m_test_fixed_array_exhaustive!(ShortArray, u32, 1);
+    m_test_fixed_array_exhaustive!(ShortArray, u32, 2);
+    m_test_fixed_array_exhaustive!(ShortArray, u32, 3);
+    m_test_fixed_array_exhaustive!(ShortArray, u64, 15);
+    m_test_fixed_array_exhaustive!(ShortArray, u8, 33);
+    m_test_fixed_array_exhaustive!(ShortArray, u64, 200);
 
-    // m_test_fixed_array_exaustive!(LongArray, u32, 1);
-    m_test_fixed_array_exaustive!(LongArray, u32, 2);
-    m_test_fixed_array_exaustive!(LongArray, u32, 3);
-    m_test_fixed_array_exaustive!(LongArray, u64, 15);
-    m_test_fixed_array_exaustive!(LongArray, u8, 33);
+    // m_test_fixed_array_exhaustive!(LongArray, u32, 1);
+    m_test_fixed_array_exhaustive!(LongArray, u32, 2);
+    m_test_fixed_array_exhaustive!(LongArray, u32, 3);
+    m_test_fixed_array_exhaustive!(LongArray, u64, 15);
+    m_test_fixed_array_exhaustive!(LongArray, u8, 33);
 
-    m_test_fixed_array_exaustive!(FixedArray, u32, 1);
-    m_test_fixed_array_exaustive!(FixedArray, u32, 2);
-    m_test_fixed_array_exaustive!(FixedArray, u32, 3);
-    m_test_fixed_array_exaustive!(FixedArray, u64, 15);
-    m_test_fixed_array_exaustive!(FixedArray, u8, 33);
-    m_test_fixed_array_exaustive!(FixedArray, u64, 200);
-    
-    m_test_fixed_array_exaustive!(FixedArray, u64, 200);
+    m_test_fixed_array_exhaustive!(FixedArray, u32, 1);
+    m_test_fixed_array_exhaustive!(FixedArray, u32, 2);
+    m_test_fixed_array_exhaustive!(FixedArray, u32, 3);
+    m_test_fixed_array_exhaustive!(FixedArray, u64, 15);
+    m_test_fixed_array_exhaustive!(FixedArray, u8, 33);
+    m_test_fixed_array_exhaustive!(FixedArray, u64, 200);
   }
 
   #[test]
   fn test_multiway_array() {
-    // m_test_multiway_array_exaustive!(MultiWayArray, u32, 1, 1);
-    m_test_multiway_array_exaustive!(MultiWayArray, u32, 2, 1);
-    m_test_multiway_array_exaustive!(MultiWayArray, u32, 3, 1);
-    m_test_multiway_array_exaustive!(MultiWayArray, u64, 15, 1);
-    m_test_multiway_array_exaustive!(MultiWayArray, u8, 33, 1);
-    m_test_multiway_array_exaustive!(MultiWayArray, u64, 200, 1);
+    // m_test_multiway_array_exhaustive!(MultiWayArray, u32, 1, 1);
+    m_test_multiway_array_exhaustive!(MultiWayArray, u32, 2, 1);
+    m_test_multiway_array_exhaustive!(MultiWayArray, u32, 3, 1);
+    m_test_multiway_array_exhaustive!(MultiWayArray, u64, 15, 1);
+    m_test_multiway_array_exhaustive!(MultiWayArray, u8, 33, 1);
+    m_test_multiway_array_exhaustive!(MultiWayArray, u64, 200, 1);
 
-    // m_test_multiway_array_exaustive!(MultiWayArray, u32, 1, 2);
-    m_test_multiway_array_exaustive!(MultiWayArray, u32, 2, 2);
-    m_test_multiway_array_exaustive!(MultiWayArray, u32, 3, 2);
-    m_test_multiway_array_exaustive!(MultiWayArray, u64, 15, 2);
-    m_test_multiway_array_exaustive!(MultiWayArray, u8, 33, 2);
-    m_test_multiway_array_exaustive!(MultiWayArray, u64, 200, 2);
+    // m_test_multiway_array_exhaustive!(MultiWayArray, u32, 1, 2);
+    m_test_multiway_array_exhaustive!(MultiWayArray, u32, 2, 2);
+    m_test_multiway_array_exhaustive!(MultiWayArray, u32, 3, 2);
+    m_test_multiway_array_exhaustive!(MultiWayArray, u64, 15, 2);
+    m_test_multiway_array_exhaustive!(MultiWayArray, u8, 33, 2);
+    m_test_multiway_array_exhaustive!(MultiWayArray, u64, 200, 2);
 
-    // m_test_multiway_array_exaustive!(MultiWayArray, u32, 1, 4);
-    m_test_multiway_array_exaustive!(MultiWayArray, u32, 2, 4);
-    m_test_multiway_array_exaustive!(MultiWayArray, u32, 3, 4);
-    m_test_multiway_array_exaustive!(MultiWayArray, u64, 15, 4);
-    m_test_multiway_array_exaustive!(MultiWayArray, u8, 33, 4);
-    m_test_multiway_array_exaustive!(MultiWayArray, u64, 200, 4);
+    // m_test_multiway_array_exhaustive!(MultiWayArray, u32, 1, 4);
+    m_test_multiway_array_exhaustive!(MultiWayArray, u32, 2, 4);
+    m_test_multiway_array_exhaustive!(MultiWayArray, u32, 3, 4);
+    m_test_multiway_array_exhaustive!(MultiWayArray, u64, 15, 4);
+    m_test_multiway_array_exhaustive!(MultiWayArray, u8, 33, 4);
+    m_test_multiway_array_exhaustive!(MultiWayArray, u64, 200, 4);
   }
 
   #[test]
   fn test_dynamic_array() {
-    // m_test_dynamic_array_exaustive!(DynamicArray, u32, 1);
-    m_test_dynamic_array_exaustive!(DynamicArray, u32, 2);
-    m_test_dynamic_array_exaustive!(DynamicArray, u32, 3);
-    m_test_dynamic_array_exaustive!(DynamicArray, u64, 15);
-    m_test_dynamic_array_exaustive!(DynamicArray, u8, 33);
-    m_test_dynamic_array_exaustive!(DynamicArray, u64, 200);
+    // m_test_dynamic_array_exhaustive!(DynamicArray, u32, 1);
+    m_test_dynamic_array_exhaustive!(DynamicArray, u32, 2);
+    m_test_dynamic_array_exhaustive!(DynamicArray, u32, 3);
+    m_test_dynamic_array_exhaustive!(DynamicArray, u64, 15);
+    m_test_dynamic_array_exhaustive!(DynamicArray, u8, 33);
+    m_test_dynamic_array_exhaustive!(DynamicArray, u64, 200);
   }
 }

--- a/crates/datastructures/src/array.rs
+++ b/crates/datastructures/src/array.rs
@@ -346,12 +346,9 @@ impl<T, const W: usize> MultiWayArray<T, W>
 where
   T: Cmov + Pod + Default + std::fmt::Debug,
 {
-  const _ASSERT_PWR2: () = {
-      assert!(W.is_power_of_two(), "W must be a power of two due to all the ilog2's here");
-  };
-
   /// Creates a new `LongArray` with the given size `n`.
   pub fn new(n: usize) -> Self {
+    assert!(W.is_power_of_two(), "W must be a power of two due to all the ilog2's here");
     Self { data: CircuitORAM::new(n), pos_map: from_fn(|_| RecursivePositionMap::new(n)), rng: rand::rng() }
   }
 
@@ -564,13 +561,6 @@ mod tests {
     m_test_multiway_array_exaustive!(MultiWayArray, u64, 15, 2);
     m_test_multiway_array_exaustive!(MultiWayArray, u8, 33, 2);
     m_test_multiway_array_exaustive!(MultiWayArray, u64, 200, 2);
-
-    // m_test_multiway_array_exaustive!(MultiWayArray, u32, 1, 3);
-    m_test_multiway_array_exaustive!(MultiWayArray, u32, 2, 3);
-    m_test_multiway_array_exaustive!(MultiWayArray, u32, 3, 3);
-    m_test_multiway_array_exaustive!(MultiWayArray, u64, 15, 3);
-    m_test_multiway_array_exaustive!(MultiWayArray, u8, 33, 3);
-    m_test_multiway_array_exaustive!(MultiWayArray, u64, 200, 3);
 
     // m_test_multiway_array_exaustive!(MultiWayArray, u32, 1, 4);
     m_test_multiway_array_exaustive!(MultiWayArray, u32, 2, 4);

--- a/crates/datastructures/src/heap.rs
+++ b/crates/datastructures/src/heap.rs
@@ -91,7 +91,7 @@ where
     let data = &self.data;
     println!("Stash: {:?}", data.stash);
     for i in 0..data.h {
-      print!("Level {}: ", i);
+      print!("Level {i}: ");
       for j in 0..(1 << i) {
         print!("{} ", j << (data.h - 1 - i));
         print!("data.h:{} ", data.h);

--- a/crates/datastructures/src/map.rs
+++ b/crates/datastructures/src/map.rs
@@ -40,7 +40,6 @@ where
 unsafe impl<K: OHash, V: Cmov + Pod> Pod for InlineElement<K, V> {}
 impl_cmov_for_generic_pod!(InlineElement<K,V>; where K: OHash, V: Cmov + Pod);
 
-// #[repr(C)]
 #[derive(Debug, Default, Clone, Copy, Zeroable)]
 /// A struct that represents an element in a bucket.
 pub struct BucketElement<K, V>
@@ -71,7 +70,6 @@ where
 /// * The elements in the bucket that have `is_valid == true` are non empty.
 /// * The elements in the bucket that have `is_valid == false` are empty.
 /// * No two valid elements have the same key.
-// #[repr(align(64))]
 #[derive(Debug, Default, Clone, Copy, Zeroable)]
 struct Bucket<K, V>
 where

--- a/crates/datastructures/src/map.rs
+++ b/crates/datastructures/src/map.rs
@@ -10,7 +10,7 @@ use rostl_primitives::{
 
 use seq_macro::seq;
 
-use crate::{array::{DynamicArray, MultiWayArray}, queue::ShortQueue};
+use crate::{array::MultiWayArray, queue::ShortQueue};
 
 // Size of the insertion queue for deamortized insertions that failed.
 const INSERTION_QUEUE_MAX_SIZE: usize = 10;
@@ -151,9 +151,9 @@ where
 {
   /// Number of elements in the map
   size: usize,
-  /// Maximum number of elements for maximum load (max_size / load_factor)
-  capacity: usize,
-  /// Maximum number of entries in each table (buckets / load_factor)
+  /// Maximum number of elements for perfect load `(max_size / load_factor)`
+  _capacity: usize,
+  /// Maximum number of entries in each table `(buckets / load_factor)`
   table_size: usize,
   /// The two tables
   table: MultiWayArray<Bucket<K, V>, 2>,
@@ -177,7 +177,7 @@ where
     let table_size = (capacity * 5).div_ceil(4 * BUCKET_SIZE).max(2);
     Self {
       size: 0,
-      capacity,
+      _capacity: capacity,
       table_size,
       table: MultiWayArray::new(table_size),
       hash_builders: [RandomState::new(), RandomState::new()],
@@ -342,7 +342,10 @@ mod tests {
     }
   }
 
-  fn test_map_subtypes<K: OHash + Default + std::fmt::Debug, V: Cmov + Pod + Default + std::fmt::Debug>() {
+  fn test_map_subtypes<
+    K: OHash + Default + std::fmt::Debug,
+    V: Cmov + Pod + Default + std::fmt::Debug,
+  >() {
     const SZ: usize = 1024;
     let mut map: UnsortedMap<K, V> = UnsortedMap::new(SZ);
     assert_eq!(map.size, 0);

--- a/crates/datastructures/src/map.rs
+++ b/crates/datastructures/src/map.rs
@@ -40,8 +40,8 @@ where
 unsafe impl<K: OHash, V: Cmov + Pod> Pod for InlineElement<K, V> {}
 impl_cmov_for_generic_pod!(InlineElement<K,V>; where K: OHash, V: Cmov + Pod);
 
-#[derive(Debug, Default, Clone, Copy, Zeroable)]
 /// A struct that represents an element in a bucket.
+#[derive(Debug, Default, Clone, Copy, Zeroable)]
 pub struct BucketElement<K, V>
 where
   K: OHash,

--- a/crates/datastructures/src/map.rs
+++ b/crates/datastructures/src/map.rs
@@ -40,6 +40,7 @@ where
 unsafe impl<K: OHash, V: Cmov + Pod> Pod for InlineElement<K, V> {}
 impl_cmov_for_generic_pod!(InlineElement<K,V>; where K: OHash, V: Cmov + Pod);
 
+// #[repr(C)]
 #[derive(Debug, Default, Clone, Copy, Zeroable)]
 /// A struct that represents an element in a bucket.
 pub struct BucketElement<K, V>
@@ -70,7 +71,7 @@ where
 /// * The elements in the bucket that have `is_valid == true` are non empty.
 /// * The elements in the bucket that have `is_valid == false` are empty.
 /// * No two valid elements have the same key.
-#[repr(align(64))]
+// #[repr(align(64))]
 #[derive(Debug, Default, Clone, Copy, Zeroable)]
 struct Bucket<K, V>
 where

--- a/crates/datastructures/src/map.rs
+++ b/crates/datastructures/src/map.rs
@@ -324,5 +324,44 @@ mod tests {
     assert_eq!(value, 3);
   }
 
+  #[test]
+  fn test_full_map() {
+    const SZ: usize = 1024;
+    let mut map: UnsortedMap<u32, u32> = UnsortedMap::new(SZ);
+    assert_eq!(map.size, 0);
+    for i in 0..SZ as u32 {
+      map.insert(i, i * 2);
+      let mut value = 0;
+      assert!(map.get(i, &mut value));
+      assert_eq!(value, i * 2);
+      assert_eq!(map.size, (i + 1) as usize);
+      map.write(i, i * 3);
+      assert!(map.get(i, &mut value));
+      assert_eq!(value, i * 3);
+      assert_eq!(map.size, (i + 1) as usize);
+    }
+  }
+
+  fn test_map_subtypes<K: OHash + Default + std::fmt::Debug, V: Cmov + Pod + Default + std::fmt::Debug>() {
+    const SZ: usize = 1024;
+    let mut map: UnsortedMap<K, V> = UnsortedMap::new(SZ);
+    assert_eq!(map.size, 0);
+    let mut value = V::default();
+    assert!(!map.get(K::default(), &mut value));
+    map.insert(K::default(), V::default());
+    assert_eq!(map.size, 1);
+    assert!(map.get(K::default(), &mut value));
+  }
+
+  #[test]
+  fn test_map_multiple_types() {
+    test_map_subtypes::<u32, u32>();
+    test_map_subtypes::<u64, u64>();
+    test_map_subtypes::<u128, u128>();
+    test_map_subtypes::<i32, i32>();
+    test_map_subtypes::<i64, i64>();
+    test_map_subtypes::<i128, i128>();
+  }
+
   // UNDONE(git-34): Add further tests for the map.
 }

--- a/crates/datastructures/src/stack.rs
+++ b/crates/datastructures/src/stack.rs
@@ -88,7 +88,7 @@ where
 
     out.cmov(&imse.value, real);
     self.top.cmov(&imse.next, real);
-    self.size.cmov(&(self.size - 1), real);
+    self.size.cmov(&self.size.wrapping_sub(1), real);
   }
 }
 
@@ -123,14 +123,14 @@ mod tests {
     stack.maybe_pop(true, &mut out);
     assert_eq!(stack.len(), 1);
     assert_eq!(out, 222);
-    out = 123;
-    stack.maybe_pop(false, &mut out);
-    assert_eq!(stack.len(), 1);
-    assert_eq!(out, 123);
     stack.maybe_pop(true, &mut out);
     assert_eq!(stack.len(), 0);
     assert_eq!(out, 100);
-  }
+    out = 123;
+    stack.maybe_pop(false, &mut out);
+    assert_eq!(stack.len(), 0);
+    assert_eq!(out, 123);
+     }
 
   // UNDONE(git-61): Benchmark Stack.
 }

--- a/crates/datastructures/src/stack.rs
+++ b/crates/datastructures/src/stack.rs
@@ -130,7 +130,7 @@ mod tests {
     stack.maybe_pop(false, &mut out);
     assert_eq!(stack.len(), 0);
     assert_eq!(out, 123);
-     }
+  }
 
   // UNDONE(git-61): Benchmark Stack.
 }

--- a/crates/oram/src/circuit_oram.rs
+++ b/crates/oram/src/circuit_oram.rs
@@ -574,7 +574,7 @@ impl<V: Cmov + Pod + Default + Clone + std::fmt::Debug> CircuitORAM<V> {
     println!("self.h: {}", self.h);
     println!("Stash: {:?}", self.stash);
     for i in 0..self.h {
-      print!("Level {}: ", i);
+      print!("Level {i}: ");
       for j in 0..(1 << i) {
         let w_j = reverse_bits(j, i);
         print!(

--- a/crates/oram/src/circuit_oram.rs
+++ b/crates/oram/src/circuit_oram.rs
@@ -522,7 +522,7 @@ impl<V: Cmov + Pod + Default + Clone + std::fmt::Debug> CircuitORAM<V> {
     // println!("{:?}", found);
 
     write_block_to_empty_slot(&mut self.stash[..S], &Block::<V> { pos: new_pos, key, value: val }); // Succeeds due to Inv1.
-    // println!("{:?}", self.stash);
+                                                                                                    // println!("{:?}", self.stash);
 
     self.evict_once_fast(pos);
     self.write_back_path(pos);

--- a/crates/oram/src/circuit_oram.rs
+++ b/crates/oram/src/circuit_oram.rs
@@ -522,7 +522,7 @@ impl<V: Cmov + Pod + Default + Clone + std::fmt::Debug> CircuitORAM<V> {
     // println!("{:?}", found);
 
     write_block_to_empty_slot(&mut self.stash[..S], &Block::<V> { pos: new_pos, key, value: val }); // Succeeds due to Inv1.
-                                                                                                    // println!("{:?}", self.stash);
+    // println!("{:?}", self.stash);
 
     self.evict_once_fast(pos);
     self.write_back_path(pos);

--- a/crates/oram/src/circuit_oram.rs
+++ b/crates/oram/src/circuit_oram.rs
@@ -26,7 +26,7 @@ const EVICTIONS_PER_OP: usize = 2; // Evictions per operations
 /// # Note
 /// * It is wrong to assume anything about the block being empty or not based on the key, please use pos.
 ///
-// #[repr(align(16))]
+#[repr(align(8))]
 #[repr(C)]
 #[derive(Clone, Copy, Zeroable)]
 pub struct Block<V>

--- a/crates/oram/src/recursive_oram.rs
+++ b/crates/oram/src/recursive_oram.rs
@@ -196,7 +196,7 @@ impl RecursivePositionMap {
     println!("Linear ORAM:");
     self.linear_oram.print_for_debug();
     for i in 0..self.h {
-      println!("Level {} ORAM:", i);
+      println!("Level {i} ORAM:");
       self.recursive_orams[i].print_for_debug();
     }
   }

--- a/crates/primitives/src/asm.rs
+++ b/crates/primitives/src/asm.rs
@@ -176,19 +176,21 @@ macro_rules! cxchg_body {
       }
     }
 
-    #[cfg(target_feature = "sse2")]
-    {
-      // Process in chunks of 16 bytes (u128)
-      while i + 16 <= self_bytes.len() {
-        let self_chunk = &mut self_bytes[i..i + 8];
-        let other_chunk = &mut other_bytes[i..i + 8];
-        let self_u128 = unsafe { &mut *(self_chunk.as_mut_ptr() as *mut u128) };
-        let other_u128 = unsafe { &mut *(other_chunk.as_mut_ptr() as *mut u128) };
 
-        self_u128.cxchg_base(other_u128, $choice);
-        i += 16;
-      }
-    }
+    // UNDONE(): This seems to be broken in rust 1.89:
+    // #[cfg(target_feature = "sse2")]
+    // {
+    //   // Process in chunks of 16 bytes (u128)
+    //   while i + 16 <= self_bytes.len() {
+    //     let self_chunk = &mut self_bytes[i..i + 16];
+    //     let other_chunk = &mut other_bytes[i..i + 16];
+    //     let self_u128 = unsafe { &mut *(self_chunk.as_mut_ptr() as *mut u128) };
+    //     let other_u128 = unsafe { &mut *(other_chunk.as_mut_ptr() as *mut u128) };
+
+    //     self_u128.cxchg_base(other_u128, $choice);
+    //     i += 16;
+    //   }
+    // }
 
 
     // Process in chunks of 8 bytes (u64)

--- a/crates/primitives/src/asm.rs
+++ b/crates/primitives/src/asm.rs
@@ -177,7 +177,7 @@ macro_rules! cxchg_body {
     }
 
 
-    // UNDONE(): This seems to be broken in rust 1.89:
+    // UNDONE(git-70): This seems to be broken in rust 1.89:
     // #[cfg(target_feature = "sse2")]
     // {
     //   // Process in chunks of 16 bytes (u128)

--- a/crates/primitives/src/asm.rs
+++ b/crates/primitives/src/asm.rs
@@ -315,6 +315,7 @@ impl_cmov_for_pod!(u64);
 impl_cmov_for_pod!(u32);
 impl_cmov_for_pod!(u16);
 impl_cmov_for_pod!(u8);
+impl_cmov_for_pod!(i128);
 impl_cmov_for_pod!(i64);
 impl_cmov_for_pod!(i32);
 impl_cmov_for_pod!(i16);

--- a/crates/sort/src/shuffle.rs
+++ b/crates/sort/src/shuffle.rs
@@ -86,9 +86,9 @@ mod tests {
     for sz in [100, 1000, 10000] {
       let mut arr: Vec<u32> = (0..sz as u32).collect();
       let mut mark = 0;
-      println!("arr: {:?}", arr);
+      println!("arr: {arr:?}");
       shuffle(&mut arr);
-      println!("arr: {:?}", arr);
+      println!("arr: {arr:?}");
       assert_eq!(arr.len(), sz);
       arr.sort();
       for (i, v) in arr.iter().enumerate() {


### PR DESCRIPTION
This improves map memory in two ways:
- Avoids having two ORAMs to store the indiviual hashtables, since the total number of elements among both hashtables is bound
- Reduces the alignment waste of individual entries

Translates to at least a measurable speedup in the benchmarks